### PR TITLE
Fusion 360 Equation Driven Curve bug...

### DIFF
--- a/cycloidal_drive_creator_app.py
+++ b/cycloidal_drive_creator_app.py
@@ -152,8 +152,8 @@ def create_equations(user_info):
 
 	elif outputformat_value == 1:	# Fusion360
 		psi = f"atan(sin({1-N}*t)/(({Fraction(R/(E*N)).limit_denominator()})-cos({1-N}*t)))"
-		x_equation = f"X = ({R}*cos(t))-({Rr}*cos(t+{psi}))-({E}*cos({N}*t))"
-		y_equation = f"Y = (-{R}*sin(t))+({Rr}*sin(t+{psi}))+({E}*sin({N}*t))"
+		x_equation = f"X = (({R}*cos(t))-({Rr}*cos(t+{psi}))-({E}*cos({N}*t))) * 0.1"
+		y_equation = f"Y = ((-{R}*sin(t))+({Rr}*sin(t+{psi}))+({E}*sin({N}*t))) * 0.1"
 
 	else:	# Python
 		psi = f"np.arctan(np.sin({1-N}*t)/(({Fraction(R/(E*N)).limit_denominator()})-np.cos({1-N}*t)))"


### PR DESCRIPTION
It turns out that the Fusion 360 Equation Driven Curve tool is off by a factor of 10, so I've added a correction 0.1 multiplier to the Fusion 360 code.  Might want to note this somewhere on the UI, in case someone fixes the Fusion 360 error.  Maybe even move the correction factor to the UI which could be used to scale the rotor.  However, I'd probably never use it for that.

BTW, Nice work adding in the Preview Omar!